### PR TITLE
Convert useState to XState

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
     "@types/node": "^12.6.9",
     "@types/react": "^16.8.24",
     "@types/react-dom": "^16.8.5",
+    "@xstate/react": "^0.7.0",
     "lodash-es": "^4.17.15",
     "match-sorter": "^4.0.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.1",
-    "typescript": "^3.5.3"
+    "typescript": "^3.5.3",
+    "xstate": "^4.6.7"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -21,7 +21,6 @@ export const App: FunctionComponent<AppProps> = ({
       const { key } = event;
 
       if (key === "/" && current.matches("hidden")) {
-        // TODO Should this go in the machine?
         event.preventDefault();
         send("SHOW");
       } else if (key === "Escape") {

--- a/src/components/App/machine.ts
+++ b/src/components/App/machine.ts
@@ -1,6 +1,6 @@
 import { assign, Machine } from "xstate";
 
-export const { machine } = Machine(
+export const machine = Machine(
   {
     id: "app",
     initial: "hidden",

--- a/src/components/App/machine.ts
+++ b/src/components/App/machine.ts
@@ -1,0 +1,39 @@
+import { assign, Machine } from "xstate";
+
+export const { machine } = Machine(
+  {
+    id: "app",
+    initial: "hidden",
+    context: {
+      target: undefined
+    },
+    states: {
+      hidden: {
+        on: {
+          SHOW: "selecting"
+        }
+      },
+      selecting: {
+        on: {
+          CANCEL: "hidden",
+          SELECT: {
+            target: "inspecting",
+            actions: "setTarget"
+          }
+        }
+      },
+      inspecting: {
+        on: {
+          CANCEL: "selecting"
+        }
+      }
+    }
+  },
+  {
+    actions: {
+      setTarget: assign({
+        target: (ctx: any, event: any) => event.target
+      })
+    }
+  }
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1819,6 +1819,11 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
+"@xstate/react@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@xstate/react/-/react-0.7.0.tgz#946986a65da73f41faaf9cfa7748dff761e1acd1"
+  integrity sha512-1ZWG/rpmA3AgtrRu9Zqz6hOF1av+McffC+LLQjESyrFYawz9pFlFB6+DqJgcID9NPnjl+S9PGzfAVpa9P02QTw==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -10516,6 +10521,11 @@ xregexp@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-4.0.0.tgz#e698189de49dd2a18cc5687b05e17c8e43943020"
   integrity sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==
+
+xstate@^4.6.7:
+  version "4.6.7"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.6.7.tgz#1f325df07d75676c90d65b17a3a56692f259fd41"
+  integrity sha512-mqgtH6BXOgjOHVDxZPyW/h6QUC5kfEggh5IN8uOitjzrdCScE/a/cwcRvgcH8CGAXYReDNvasOKD0aFBWAZ1fg==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
After some discussions with @davidkpiano, I'm giving XState a shot for handling the sequential state of the app.

- Should I use guards (e.g. `cond`) and special events for handling the keypress to do the transition (instead of the component handling it)?  My instinct is "yes", since testing a state transition seems clearer than testing component interaction.