### PR TITLE
Persist target in URL

### DIFF
--- a/packages/codevisor/components/Store/Target.ts
+++ b/packages/codevisor/components/Store/Target.ts
@@ -10,7 +10,7 @@ export const Target = types
     isLocked: false
   })
   .volatile(self => ({
-    element: undefined as undefined | HTMLElement
+    element: null as null | HTMLElement
   }))
   .views(self => ({
     get debugSource() {
@@ -44,6 +44,33 @@ export const Target = types
           return self.element[key];
         }
       }
+    },
+
+    get selector() {
+      let { element } = self;
+
+      if (!element) {
+        return null;
+      }
+
+      const selectors = [];
+
+      while (element) {
+        selectors.unshift(
+          [
+            element.tagName.toLowerCase(),
+            element.className.split(" ").join(".")
+          ]
+            .filter(Boolean)
+            .join(".")
+            .split(":")
+            .join("\\:")
+        );
+
+        element = element.parentElement;
+      }
+
+      return selectors.join(" > ");
     }
   }))
   .actions(self => ({
@@ -89,7 +116,7 @@ export const Target = types
     },
 
     unset() {
-      self.element = undefined;
+      self.element = null;
       self.isLocked = false;
     }
   }));

--- a/packages/codevisor/components/Store/index.ts
+++ b/packages/codevisor/components/Store/index.ts
@@ -157,7 +157,17 @@ export const Store = types
       self.document = iframe.contentWindow.document;
       self.root = self.document.querySelector("body");
 
-      self.target.unset();
+      const { selector } = self.target;
+
+      const element = selector
+        ? (self.document.querySelector(selector) as HTMLElement)
+        : null;
+
+      if (element) {
+        self.target.set(element);
+      } else {
+        self.target.unset();
+      }
     },
 
     handleTargetHover(element: HTMLElement) {


### PR DESCRIPTION
- [x] Persist the path to the element in the URL (e.g. `unique-selector`?)
- [x] With each `onLoad`, reselect the `target`.
